### PR TITLE
Task scheduling abstraction

### DIFF
--- a/src/gemini.cpp
+++ b/src/gemini.cpp
@@ -32,11 +32,11 @@ int main()
     GLFWwindow* window = glfwCreateWindow(WIDTH, HEIGHT, "gemini", nullptr, nullptr);
 
     // Initialize systems
-    SInput::init_input(0);
-    SPhysics::init_physics(1);
-    SAnimation::init_animation(2);
-    SAI::init_ai(3);
-    SRendering::init_rendering(4, window);
+    SInput::init_input(&MTaskScheduling::s_stacks[0]);
+    SPhysics::init_physics(&MTaskScheduling::s_stacks[1]);
+    SAnimation::init_animation(&MTaskScheduling::s_stacks[2]);
+    SAI::init_ai(&MTaskScheduling::s_stacks[3]);
+    SRendering::init_rendering(&MTaskScheduling::s_stacks[4], window);
 
     // Launch worker threads
     std::thread workers[MTaskScheduling::MAX_NUM_WORKER_THREADS];
@@ -60,6 +60,7 @@ int main()
 
     // Clear resources
     SRendering::clear_rendering();
+    MTaskScheduling::clear_scheduler();
     MMemory::clear_memory();
 
     // Destroy window

--- a/src/systems/ai/AI.cpp
+++ b/src/systems/ai/AI.cpp
@@ -5,14 +5,16 @@
 #include <unistd.h> // usleep()
 #include <iostream>
 
+using namespace MTaskScheduling;
+
 namespace SAI
 {
-    uint32_t system_id;
+    task_stack_t* task_stack;
     MMemory::LinearAllocator32kb task_args_memory;
 
-    void init_ai(uint32_t assigned_system_id)
+    void init_ai(task_stack_t* assigned_task_stack)
     {
-        system_id = assigned_system_id;
+        task_stack = assigned_task_stack;
         task_args_memory.Init();
         submit_tasks(nullptr, 0);
     }
@@ -24,80 +26,61 @@ namespace SAI
     {
         task_args_memory.Clear();
 
-        uint32_t stack_size = 1;
-        MTaskScheduling::task_t task;
-        task.execute = submit_tasks;
-        task.args = nullptr;
-        task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-        task.checkpoints_current_frame = MTaskScheduling::SCP_AI2;
-        MTaskScheduling::s_stacks[system_id][stack_size] = task;
+        begin_task_recording(task_stack);
+
+        record_task(task_stack, {submit_tasks, nullptr, ECP_NONE, ECP_AI2});
 
         // 10 tasks in task group 2
         num_executed_group2.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group2;
             task_group2_args_t* args = new(task_args_memory) task_group2_args_t;
             args->counter = &num_executed_group2;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_AI1;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group2, args, ECP_NONE, ECP_AI1});
         }
 
         // 4 independent tasks
         for (uint32_t i = 0; i < 4; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = independent_task;
             independent_task_args_t* args = new(task_args_memory) independent_task_args_t;
             args->some_param = 42 + i;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {independent_task, args, ECP_NONE, ECP_NONE});
         }
 
         // 10 tasks in task group 1
         num_executed_group1.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group1;
             task_group1_args_t* args = new(task_args_memory) task_group1_args_t;
             args->counter = &num_executed_group1;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group1, args, ECP_NONE, ECP_NONE});
         }
 
-        MTaskScheduling::s_stack_sizes[system_id].store((MTaskScheduling::s_iterations[system_id] << 7) | stack_size, std::memory_order_release);
+        submit_task_recording(task_stack);
 
-        return MTaskScheduling::SCP_NONE;
+        return ECP_NONE;
     }
 
     uint64_t independent_task(void* args, uint32_t thread_id)
     {
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
-        return MTaskScheduling::SCP_NONE;
+        return ECP_NONE;
     }
 
     uint64_t task_group1(void* args, uint32_t thread_id)
     {
         task_group1_args_t* pargs = (task_group1_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_AI1;
+            reached_checkpoints = ECP_AI1;
 
         return reached_checkpoints;
     }
@@ -106,12 +89,12 @@ namespace SAI
     {
         task_group2_args_t* pargs = (task_group2_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_AI2;
+            reached_checkpoints = ECP_AI2;
 
         return reached_checkpoints;
     }

--- a/src/systems/ai/AI.h
+++ b/src/systems/ai/AI.h
@@ -1,15 +1,16 @@
 #pragma once
 
+#include "managers/TaskScheduling.h"
 #include "managers/Memory.h"
 
 #include <atomic>
 
 namespace SAI
 {
-    extern uint32_t system_id;
+    extern MTaskScheduling::task_stack_t* task_stack;
     extern MMemory::LinearAllocator32kb task_args_memory;
 
-    void init_ai(uint32_t);
+    void init_ai(MTaskScheduling::task_stack_t*);
 
     uint64_t submit_tasks(void*, uint32_t);
 

--- a/src/systems/animation/Animation.cpp
+++ b/src/systems/animation/Animation.cpp
@@ -5,14 +5,16 @@
 #include <unistd.h> // usleep()
 #include <iostream>
 
+using namespace MTaskScheduling;
+
 namespace SAnimation
 {
-    uint32_t system_id;
+    task_stack_t* task_stack;
     MMemory::LinearAllocator32kb task_args_memory;
 
-    void init_animation(uint32_t assigned_system_id)
+    void init_animation(task_stack_t* assigned_task_stack)
     {
-        system_id = assigned_system_id;
+        task_stack = assigned_task_stack;
         task_args_memory.Init();
         submit_tasks(nullptr, 0);
     }
@@ -25,109 +27,80 @@ namespace SAnimation
     {
         task_args_memory.Clear();
 
-        uint32_t stack_size = 1;
-        MTaskScheduling::task_t task;
-        task.execute = submit_tasks;
-        task.args = nullptr;
-        task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-        task.checkpoints_current_frame = MTaskScheduling::SCP_ANIMATION3;
-        MTaskScheduling::s_stacks[system_id][stack_size] = task;
+        begin_task_recording(task_stack);
+
+        record_task(task_stack, {submit_tasks, nullptr, ECP_NONE, ECP_ANIMATION3});
 
         // 10 tasks in task group 3
         num_executed_group3.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group3;
             task_group3_args_t* args = new(task_args_memory) task_group3_args_t;
             args->counter = &num_executed_group3;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_ANIMATION2;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group3, args, ECP_NONE, ECP_ANIMATION2});
         }
 
         // 4 independent tasks
         for (uint32_t i = 0; i < 4; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = independent_task;
             independent_task_args_t* args = new(task_args_memory) independent_task_args_t;
             args->some_param = 42 - i;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {independent_task, args, ECP_NONE, ECP_NONE});
         }
 
         // 10 tasks in task group 2
         num_executed_group2.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group2;
             task_group2_args_t* args = new(task_args_memory) task_group2_args_t;
             args->counter = &num_executed_group2;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_INPUT1 | MTaskScheduling::SCP_ANIMATION1;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group2, args, ECP_NONE, ECP_INPUT1 | ECP_ANIMATION1});
         }
 
         // 4 independent tasks
         for (uint32_t i = 0; i < 4; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = independent_task;
             independent_task_args_t* args = new(task_args_memory) independent_task_args_t;
             args->some_param = 42 + i;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {independent_task, args, ECP_NONE, ECP_NONE});
         }
 
         // 10 tasks in task group 1
         num_executed_group1.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group1;
             task_group1_args_t* args = new(task_args_memory) task_group1_args_t;
             args->counter = &num_executed_group1;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group1, args, ECP_NONE, ECP_NONE});
         }
 
-        MTaskScheduling::s_stack_sizes[system_id].store((MTaskScheduling::s_iterations[system_id] << 7) | stack_size, std::memory_order_release);
+        submit_task_recording(task_stack);
 
-        return MTaskScheduling::SCP_NONE;
+        return ECP_NONE;
     }
 
     uint64_t independent_task(void* args, uint32_t thread_id)
     {
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
-        return MTaskScheduling::SCP_NONE;
+        return ECP_NONE;
     }
 
     uint64_t task_group1(void* args, uint32_t thread_id)
     {
         task_group1_args_t* pargs = (task_group1_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_ANIMATION1;
+            reached_checkpoints = ECP_ANIMATION1;
 
         return reached_checkpoints;
     }
@@ -136,12 +109,12 @@ namespace SAnimation
     {
         task_group2_args_t* pargs = (task_group2_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_ANIMATION2;
+            reached_checkpoints = ECP_ANIMATION2;
 
         return reached_checkpoints;
     }
@@ -150,12 +123,12 @@ namespace SAnimation
     {
         task_group3_args_t* pargs = (task_group3_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_ANIMATION3;
+            reached_checkpoints = ECP_ANIMATION3;
 
         return reached_checkpoints;
     }

--- a/src/systems/animation/Animation.h
+++ b/src/systems/animation/Animation.h
@@ -1,15 +1,16 @@
 #pragma once
 
+#include "managers/TaskScheduling.h"
 #include "managers/Memory.h"
 
 #include <atomic>
 
 namespace SAnimation
 {
-    extern uint32_t system_id;
+    extern MTaskScheduling::task_stack_t* task_stack;
     extern MMemory::LinearAllocator32kb task_args_memory;
 
-    void init_animation(uint32_t);
+    void init_animation(MTaskScheduling::task_stack_t*);
 
     uint64_t submit_tasks(void*, uint32_t);
 

--- a/src/systems/input/Input.h
+++ b/src/systems/input/Input.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "managers/TaskScheduling.h"
 #include "managers/Memory.h"
 
 #include <atomic>
@@ -10,7 +11,7 @@
 
 namespace SInput
 {
-    extern uint32_t system_id;
+    extern MTaskScheduling::task_stack_t* task_stack;
     extern MMemory::LinearAllocator32kb task_args_memory;
     struct input_loop_sync_t
     {
@@ -20,7 +21,7 @@ namespace SInput
         bool input_gathered = false;
     } extern input_loop_sync;
 
-    void init_input(uint32_t);
+    void init_input(MTaskScheduling::task_stack_t*);
     void input_loop(GLFWwindow*);
     void key_callback(GLFWwindow*, int, int, int, int);
 

--- a/src/systems/physics/Physics.cpp
+++ b/src/systems/physics/Physics.cpp
@@ -5,14 +5,16 @@
 #include <unistd.h> // usleep()
 #include <iostream>
 
+using namespace MTaskScheduling;
+
 namespace SPhysics
 {
-    uint32_t system_id;
+    task_stack_t* task_stack;
     MMemory::LinearAllocator32kb task_args_memory;
 
-    void init_physics(uint32_t assigned_system_id)
+    void init_physics(task_stack_t* assigned_task_stack)
     {
-        system_id = assigned_system_id;
+        task_stack = assigned_task_stack;
         task_args_memory.Init();
         submit_tasks(nullptr, 0);
     }
@@ -26,152 +28,108 @@ namespace SPhysics
     {
         task_args_memory.Clear();
 
-        uint32_t stack_size = 1;
-        MTaskScheduling::task_t task;
-        task.execute = submit_tasks;
-        task.args = nullptr;
-        task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-        task.checkpoints_current_frame = MTaskScheduling::SCP_PHYSICS4;
-        MTaskScheduling::s_stacks[system_id][stack_size] = task;
+        begin_task_recording(task_stack);
+
+        record_task(task_stack, {submit_tasks, nullptr, ECP_NONE, ECP_PHYSICS4});
 
         // 10 tasks in task group 4
         num_executed_group4.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group4;
             task_group4_args_t* args = new(task_args_memory) task_group4_args_t;
             args->counter = &num_executed_group4;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_PHYSICS3;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group4, args, ECP_NONE, ECP_PHYSICS3});
         }
 
         // 4 independent tasks
         for (uint32_t i = 0; i < 4; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = independent_task;
             independent_task_args_t* args = new(task_args_memory) independent_task_args_t;
             args->some_param = 42 - i;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {independent_task, args, ECP_NONE, ECP_NONE});
         }
 
         // 10 tasks in task group 3
         num_executed_group3.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group3;
             task_group3_args_t* args = new(task_args_memory) task_group3_args_t;
             args->counter = &num_executed_group3;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_RENDERING2;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_PHYSICS2;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group3, args, ECP_RENDERING2, ECP_PHYSICS2});
         }
 
         // 4 independent tasks
         for (uint32_t i = 0; i < 4; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = independent_task;
             independent_task_args_t* args = new(task_args_memory) independent_task_args_t;
             args->some_param = 42 - i;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {independent_task, args, ECP_NONE, ECP_NONE});
         }
 
         // 10 tasks in task group 2
         num_executed_group2.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group2;
             task_group2_args_t* args = new(task_args_memory) task_group2_args_t;
             args->counter = &num_executed_group2;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_PHYSICS1;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group2, args, ECP_NONE, ECP_PHYSICS1});
         }
 
         // 4 independent tasks
         for (uint32_t i = 0; i < 4; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = independent_task;
             independent_task_args_t* args = new(task_args_memory) independent_task_args_t;
             args->some_param = 42 + i;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {independent_task, args, ECP_NONE, ECP_NONE});
         }
 
         // 10 tasks in task group 1
         num_executed_group1.store(9, std::memory_order_relaxed);
         for (uint32_t i = 0; i < 10; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = task_group1;
             task_group1_args_t* args = new(task_args_memory) task_group1_args_t;
             args->counter = &num_executed_group1;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_INPUT1;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {task_group1, args, ECP_NONE, ECP_INPUT1});
         }
 
         // 4 independent tasks
         for (uint32_t i = 0; i < 4; ++i)
         {
-            ++stack_size;
-            MTaskScheduling::task_t task;
-            task.execute = independent_task;
             independent_task_args_t* args = new(task_args_memory) independent_task_args_t;
             args->some_param = 42 + i;
-            task.args = args;
-            task.checkpoints_previous_frame = MTaskScheduling::SCP_NONE;
-            task.checkpoints_current_frame = MTaskScheduling::SCP_NONE;
-            MTaskScheduling::s_stacks[system_id][stack_size] = task;
+
+            record_task(task_stack, {independent_task, args, ECP_NONE, ECP_NONE});
         }
 
-        MTaskScheduling::s_stack_sizes[system_id].store((MTaskScheduling::s_iterations[system_id] << 7) | stack_size, std::memory_order_release);
+        submit_task_recording(task_stack);
 
-        return MTaskScheduling::SCP_NONE;
+        return ECP_NONE;
     }
 
     uint64_t independent_task(void* args, uint32_t thread_id)
     {
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
-        return MTaskScheduling::SCP_NONE;
+        return ECP_NONE;
     }
 
     uint64_t task_group1(void* args, uint32_t thread_id)
     {
         task_group1_args_t* pargs = (task_group1_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_PHYSICS1;
+            reached_checkpoints = ECP_PHYSICS1;
 
         return reached_checkpoints;
     }
@@ -180,12 +138,12 @@ namespace SPhysics
     {
         task_group2_args_t* pargs = (task_group2_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_PHYSICS2;
+            reached_checkpoints = ECP_PHYSICS2;
 
         return reached_checkpoints;
     }
@@ -194,12 +152,12 @@ namespace SPhysics
     {
         task_group3_args_t* pargs = (task_group3_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_PHYSICS3;
+            reached_checkpoints = ECP_PHYSICS3;
 
         return reached_checkpoints;
     }
@@ -208,12 +166,12 @@ namespace SPhysics
     {
         task_group4_args_t* pargs = (task_group4_args_t*) args;
 
-        MTaskScheduling::simulate_work();
+        simulate_work();
 
         uint32_t count = pargs->counter->fetch_sub(1, std::memory_order_release);
-        uint64_t reached_checkpoints = MTaskScheduling::SCP_NONE;
+        uint64_t reached_checkpoints = ECP_NONE;
         if (count == 0)
-            reached_checkpoints = MTaskScheduling::SCP_PHYSICS4;
+            reached_checkpoints = ECP_PHYSICS4;
 
         return reached_checkpoints;
     }

--- a/src/systems/physics/Physics.h
+++ b/src/systems/physics/Physics.h
@@ -1,15 +1,16 @@
 #pragma once
 
+#include "managers/TaskScheduling.h"
 #include "managers/Memory.h"
 
 #include <atomic>
 
 namespace SPhysics
 {
-    extern uint32_t system_id;
+    extern MTaskScheduling::task_stack_t* task_stack;
     extern MMemory::LinearAllocator32kb task_args_memory;
 
-    void init_physics(uint32_t);
+    void init_physics(MTaskScheduling::task_stack_t*);
 
     uint64_t submit_tasks(void*, uint32_t);
 

--- a/src/systems/rendering/Rendering.h
+++ b/src/systems/rendering/Rendering.h
@@ -1,17 +1,19 @@
 #pragma once
 
+#include "managers/TaskScheduling.h"
 #include "managers/Memory.h"
 
 #include <atomic>
 
+// forward declarations
 struct GLFWwindow;
 
 namespace SRendering
 {
-    extern uint32_t system_id;
+    extern MTaskScheduling::task_stack_t* task_stack;
     extern MMemory::LinearAllocator32kb task_args_memory;
 
-    void init_rendering(uint32_t, GLFWwindow*);
+    void init_rendering(MTaskScheduling::task_stack_t*, GLFWwindow*);
     void clear_rendering();
 
     uint64_t submit_tasks(void*, uint32_t);


### PR DESCRIPTION
- Added a simple interface for scheduling tasks:
```
begin_task_recording(task_stack);
record_task(task_stack, task);
...
submit_task_recording(task_stack);
```
- Task stack sizes are now separated in memory to avoid false sharing.
- Smaller cosmetic changes and added some comments to scheduling code.
- Scheduling checkpoints (SCP) are now called Execution checkpoints (ECP).